### PR TITLE
Replace sielabs URLs with rootelectronics

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -45,24 +45,12 @@
     <priority>0.6</priority>
   </url>
 
-  <!-- — sielabs.html — -->
+  <!-- — rootelectronics.html — -->
   <url>
-    <loc>https://www.sie.com.ar/sielabs.html</loc>
+    <loc>https://www.sie.com.ar/rootelectronics.html</loc>
     <lastmod>2025-05-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
-  </url>
-  <url>
-    <loc>https://www.sie.com.ar/sielabs.html#inicio</loc>
-    <lastmod>2025-05-04</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>https://www.sie.com.ar/sielabs.html#servicios</loc>
-    <lastmod>2025-05-04</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
   </url>
 
 </urlset>


### PR DESCRIPTION
## Summary
- point sitemap `sielabs.html` entries to `rootelectronics.html`
- drop obsolete fragment URLs for sections not present in `rootelectronics.html`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7831f621c832eaa01bd26ae1f9b18