### PR TITLE
Fix ROOT electronics link extension

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
         </nav>
       </div>
       <div class="col-2">
-        <a href="rootelectronics" class="btn-labs">ROOT electronics</a>
+        <a href="rootelectronics.html" class="btn-labs">ROOT electronics</a>
         <!-- (Opcional) subtítulo o tagline -->
         <!-- <p class="tagline">Soluciones integrales de hardware & testing.</p> -->
       </div>


### PR DESCRIPTION
## Summary
- correct ROOT electronics link to include `.html` extension

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7831e0a84832eaea224578f809489